### PR TITLE
Update index.js

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -94,16 +94,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  return FullscreenControl;
 	}(_reactLeaflet.MapControl);
 
-	FullscreenControl.propTypes = {
-	  position: _react.PropTypes.string,
-	  title: _react.PropTypes.string,
-	  titleCancel: _react.PropTypes.string,
-	  content: _react.PropTypes.node,
-	  forceSeparateButton: _react.PropTypes.bool,
-	  forcePseudoFullscreen: _react.PropTypes.bool,
-	  fullscreenElement: _react.PropTypes.bool
-	};
-
 	exports.default = FullscreenControl;
 
 /***/ },


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5.
Could you remove these code?